### PR TITLE
fix: at not null constraint to bucket and object rows

### DIFF
--- a/deploy/s3-image-sources.sql
+++ b/deploy/s3-image-sources.sql
@@ -5,8 +5,8 @@ BEGIN;
 
 CREATE TABLE s3_image_sources(
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    bucket TEXT,
-    object TEXT,
+    bucket TEXT NOT NULL,
+    object TEXT NOT NULL,
     image_id INTEGER REFERENCES images(id) ON DELETE restrict,
     UNIQUE (bucket, object)
 );

--- a/t/test-s3-image-sources.pg
+++ b/t/test-s3-image-sources.pg
@@ -9,9 +9,11 @@ SELECT col_type_is( 's3_image_sources', 'id', 'integer' );
 
 SELECT has_column( 's3_image_sources', 'bucket' );
 SELECT col_type_is( 's3_image_sources', 'bucket', 'text' );
+SELECT col_not_null( 's3_image_sources', 'bucket' );
 
 SELECT has_column( 's3_image_sources', 'object' );
 SELECT col_type_is( 's3_image_sources', 'object', 'text' );
+SELECT col_not_null( 's3_image_sources', 'object' );
 
 SELECT has_column( 's3_image_sources', 'image_id' );
 SELECT col_type_is( 's3_image_sources', 'image_id', 'integer' );


### PR DESCRIPTION
For something to be stored in an s3 service, it _must_ have a bucket and an object key.