### PR TITLE
chore: remove climb-description-type-defaults migration

### DIFF
--- a/deploy/climb-description-type-defaults.sql
+++ b/deploy/climb-description-type-defaults.sql
@@ -1,9 +1,0 @@
--- Deploy climb-pg:climb-description-types-defaults to pg
--- requires: climb-description-types
-
-BEGIN;
-
-INSERT INTO climb_description_types(name)
-    VALUES ('description');
-
-COMMIT;

--- a/revert/climb-description-type-defaults.sql
+++ b/revert/climb-description-type-defaults.sql
@@ -1,8 +1,0 @@
--- Revert climb-pg:climb-description-types-defaults from pg
-
-BEGIN;
-
-DELETE FROM climb_description_types
-    WHERE name = 'description';
-
-COMMIT;

--- a/verify/climb-description-type-defaults.sql
+++ b/verify/climb-description-type-defaults.sql
@@ -1,9 +1,0 @@
--- Verify climb-pg:climb-description-types-defaults on pg
-
-BEGIN;
-
-SELECT 1/count(*)
-    FROM climb_description_types
-    WHERE name = 'description';
-
-ROLLBACK;


### PR DESCRIPTION
This was mistakenly committed from a working branch before the description column was added to each entity.