### PR TITLE
feat(formations): allow any geometry

### DIFF
--- a/schema/deploy/climb/formations.sql
+++ b/schema/deploy/climb/formations.sql
@@ -11,7 +11,7 @@ CREATE TABLE climb.formations (
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name TEXT,
     description TEXT,
-    location geometry(POINT, 4326),
+    geom geometry(Geometry, 4326),
 
     -- possible "parents"
     region_id INTEGER REFERENCES climb.regions(id),

--- a/schema/t/climb/formations.pg
+++ b/schema/t/climb/formations.pg
@@ -17,9 +17,9 @@ SELECT has_column( 'formations', 'description' );
 SELECT col_type_is( 'formations', 'description', 'text' );
 SELECT col_is_null( 'formations', 'description' );
 
-SELECT has_column( 'formations', 'location' );
-SELECT col_type_is( 'formations', 'location', 'geometry(Point,4326)' );
-SELECT col_is_null( 'formations', 'location' );
+SELECT has_column( 'formations', 'geom' );
+SELECT col_type_is( 'formations', 'geom', 'geometry(Geometry,4326)' );
+SELECT col_is_null( 'formations', 'geom' );
 
 SELECT has_column( 'formations', 'region_id' );
 SELECT col_type_is( 'formations', 'region_id', 'integer' );

--- a/schema/verify/climb/formations.sql
+++ b/schema/verify/climb/formations.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-SELECT id, name, description, location, region_id, crag_id, sector_id
+SELECT id, name, description, geom, region_id, crag_id, sector_id
     FROM climb.formations
     WHERE FALSE;
 


### PR DESCRIPTION
This patch renames the `location` column to `geom` and retypes it from `geometry(Point,...)` to `geometry(Geometry,...)`. This effectively allows the user to specify any geometry for a particular formation whether that be a point/pin, the shape of the formations as a boulder, or the length of a wall.