### PR TITLE
feat!: using uuid as primary keys

### DIFF
--- a/schema/deploy/climb/ascent-members.sql
+++ b/schema/deploy/climb/ascent-members.sql
@@ -6,8 +6,8 @@
 BEGIN;
 
 CREATE TABLE climb.ascent_members (
-    ascent_id INTEGER NOT NULL REFERENCES climb.ascents(id) ON DELETE CASCADE,
-    climber_id INTEGER NOT NULL REFERENCES climb.climbers(id),
+    ascent_id UUID NOT NULL REFERENCES climb.ascents(id) ON DELETE CASCADE,
+    climber_id UUID NOT NULL REFERENCES climb.climbers(id),
     role TEXT[] NOT NULL DEFAULT '{}',
     PRIMARY KEY (ascent_id, climber_id)
 );

--- a/schema/deploy/climb/ascents.sql
+++ b/schema/deploy/climb/ascents.sql
@@ -5,8 +5,8 @@
 BEGIN;
 
 CREATE TABLE climb.ascents (
-    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    climb_id INTEGER NOT NULL REFERENCES climb.climbs(id) ON DELETE CASCADE,
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    climb_id UUID NOT NULL REFERENCES climb.climbs(id) ON DELETE CASCADE,
     ascent_window DATERANGE,
     notes TEXT,
     style TEXT[] NOT NULL DEFAULT '{}',

--- a/schema/deploy/climb/climbers.sql
+++ b/schema/deploy/climb/climbers.sql
@@ -4,7 +4,7 @@
 BEGIN;
 
 CREATE TABLE climb.climbers (
-    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
     first_name TEXT NOT NULL,
     last_name TEXT NOT NULL
 );

--- a/schema/deploy/climb/climbs.sql
+++ b/schema/deploy/climb/climbs.sql
@@ -8,16 +8,16 @@
 BEGIN;
 
 CREATE TABLE climb.climbs (
-    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
     name TEXT,
     description TEXT,
     grade TEXT,
 
     -- possible "parents"
-    region_id INTEGER REFERENCES climb.regions(id),
-    crag_id INTEGER REFERENCES climb.crags(id),
-    sector_id INTEGER REFERENCES climb.sectors(id),
-    formation_id INTEGER REFERENCES climb.formations(id),
+    region_id UUID REFERENCES climb.regions(id),
+    crag_id UUID REFERENCES climb.crags(id),
+    sector_id UUID REFERENCES climb.sectors(id),
+    formation_id UUID REFERENCES climb.formations(id),
 
     -- exclusive-or parent enforcement
     CONSTRAINT at_most_one_parent CHECK ( num_nonnulls(region_id, crag_id, sector_id, formation_id) < 2 )

--- a/schema/deploy/climb/crags.sql
+++ b/schema/deploy/climb/crags.sql
@@ -5,10 +5,10 @@
 BEGIN;
 
 CREATE TABLE climb.crags (
-    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
     name TEXT,
     description TEXT,
-    region_id INTEGER REFERENCES climb.regions(id)
+    region_id UUID REFERENCES climb.regions(id)
 );
 
 COMMENT ON TABLE climb.crags IS 'Distinct climbing areas with limited scope.';

--- a/schema/deploy/climb/formations.sql
+++ b/schema/deploy/climb/formations.sql
@@ -8,15 +8,15 @@
 BEGIN;
 
 CREATE TABLE climb.formations (
-    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
     name TEXT,
     description TEXT,
     geom geometry(Geometry, 4326),
 
     -- possible "parents"
-    region_id INTEGER REFERENCES climb.regions(id),
-    crag_id INTEGER REFERENCES climb.crags(id),
-    sector_id INTEGER REFERENCES climb.sectors(id),
+    region_id UUID REFERENCES climb.regions(id),
+    crag_id UUID REFERENCES climb.crags(id),
+    sector_id UUID REFERENCES climb.sectors(id),
 
     -- exclusive-or parent enforcement
     CONSTRAINT at_most_one_parent CHECK ( num_nonnulls(region_id, crag_id, sector_id) < 2 )

--- a/schema/deploy/climb/regions.sql
+++ b/schema/deploy/climb/regions.sql
@@ -4,7 +4,7 @@
 BEGIN;
 
 CREATE TABLE climb.regions (
-    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
     name TEXT,
     description TEXT
 );

--- a/schema/deploy/climb/sectors.sql
+++ b/schema/deploy/climb/sectors.sql
@@ -5,10 +5,10 @@
 BEGIN;
 
 CREATE TABLE climb.sectors (
-    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
     name TEXT,
     description TEXT,
-    crag_id INTEGER NOT NULL REFERENCES climb.crags(id)
+    crag_id UUID NOT NULL REFERENCES climb.crags(id)
 );
 
 COMMENT ON TABLE climb.sectors IS 'Subdivisions of a crag. Generally used for organization purposes to further specify or group formations or climbs.';

--- a/schema/t/climb/ascent-members.pg
+++ b/schema/t/climb/ascent-members.pg
@@ -7,12 +7,12 @@ SET search_path TO climb,public;
 SELECT has_table( 'ascent_members' );
 
 SELECT has_column( 'ascent_members', 'ascent_id' );
-SELECT col_type_is( 'ascent_members', 'ascent_id', 'integer' );
+SELECT col_type_is( 'ascent_members', 'ascent_id', 'uuid' );
 SELECT col_not_null( 'ascent_members', 'ascent_id' );
 SELECT fk_ok( 'ascent_members', 'ascent_id', 'ascents', 'id' );
 
 SELECT has_column( 'ascent_members', 'climber_id' );
-SELECT col_type_is( 'ascent_members', 'climber_id', 'integer' );
+SELECT col_type_is( 'ascent_members', 'climber_id', 'uuid' );
 SELECT col_not_null( 'ascent_members', 'climber_id' );
 SELECT fk_ok( 'ascent_members', 'climber_id', 'climbers', 'id' );
 

--- a/schema/t/climb/ascents.pg
+++ b/schema/t/climb/ascents.pg
@@ -7,11 +7,11 @@ SET search_path TO climb,public;
 SELECT has_table( 'ascents' );
 
 SELECT has_column( 'ascents', 'id' );
-SELECT col_type_is( 'ascents', 'id', 'integer' );
+SELECT col_type_is( 'ascents', 'id', 'uuid' );
 SELECT col_is_pk( 'ascents', 'id' );
 
 SELECT has_column( 'ascents', 'climb_id' );
-SELECT col_type_is( 'ascents', 'climb_id', 'integer' );
+SELECT col_type_is( 'ascents', 'climb_id', 'uuid' );
 SELECT col_not_null( 'ascents', 'climb_id' );
 SELECT fk_ok( 'ascents', 'climb_id', 'climbs', 'id' );
 

--- a/schema/t/climb/climbers.pg
+++ b/schema/t/climb/climbers.pg
@@ -6,7 +6,7 @@ SET search_path TO climb,public;
 SELECT has_table( 'climbers' );
 
 SELECT has_column( 'climbers', 'id' );
-SELECT col_type_is( 'climbers', 'id', 'integer' );
+SELECT col_type_is( 'climbers', 'id', 'uuid' );
 SELECT col_is_pk( 'climbers', 'id' );
 
 SELECT has_column( 'climbers', 'first_name' );

--- a/schema/t/climb/climbs.pg
+++ b/schema/t/climb/climbs.pg
@@ -6,7 +6,7 @@ SET search_path TO climb,public;
 SELECT has_table( 'climbs' );
 
 SELECT has_column( 'climbs', 'id' );
-SELECT col_type_is( 'climbs', 'id', 'integer' );
+SELECT col_type_is( 'climbs', 'id', 'uuid' );
 SELECT col_is_pk( 'climbs', 'id' );
 
 SELECT has_column( 'climbs', 'name' );
@@ -22,22 +22,22 @@ SELECT col_type_is( 'climbs', 'grade', 'text' );
 SELECT col_is_null( 'climbs', 'grade' );
 
 SELECT has_column( 'climbs', 'region_id' );
-SELECT col_type_is( 'climbs', 'region_id', 'integer' );
+SELECT col_type_is( 'climbs', 'region_id', 'uuid' );
 SELECT col_is_null( 'climbs', 'region_id' );
 SELECT fk_ok( 'climbs', 'region_id', 'regions', 'id' );
 
 SELECT has_column( 'climbs', 'crag_id' );
-SELECT col_type_is( 'climbs', 'crag_id', 'integer' );
+SELECT col_type_is( 'climbs', 'crag_id', 'uuid' );
 SELECT col_is_null( 'climbs', 'crag_id' );
 SELECT fk_ok( 'climbs', 'crag_id', 'crags', 'id' );
 
 SELECT has_column( 'climbs', 'sector_id' );
-SELECT col_type_is( 'climbs', 'sector_id', 'integer' );
+SELECT col_type_is( 'climbs', 'sector_id', 'uuid' );
 SELECT col_is_null( 'climbs', 'sector_id' );
 SELECT fk_ok( 'climbs', 'sector_id', 'sectors', 'id' );
 
 SELECT has_column( 'climbs', 'formation_id' );
-SELECT col_type_is( 'climbs', 'formation_id', 'integer' );
+SELECT col_type_is( 'climbs', 'formation_id', 'uuid' );
 SELECT col_is_null( 'climbs', 'formation_id' );
 SELECT fk_ok( 'climbs', 'formation_id', 'formations', 'id' );
 

--- a/schema/t/climb/crags.pg
+++ b/schema/t/climb/crags.pg
@@ -6,7 +6,7 @@ SET search_path TO climb,public;
 SELECT has_table( 'crags' );
 
 SELECT has_column( 'crags', 'id' );
-SELECT col_type_is( 'crags', 'id', 'integer' );
+SELECT col_type_is( 'crags', 'id', 'uuid' );
 SELECT col_is_pk( 'crags', 'id' );
 
 SELECT has_column( 'crags', 'name' );
@@ -18,7 +18,7 @@ SELECT col_type_is( 'crags', 'description', 'text' );
 SELECT col_is_null( 'crags', 'description' );
 
 SELECT has_column( 'crags', 'region_id' );
-SELECT col_type_is( 'crags', 'region_id', 'integer' );
+SELECT col_type_is( 'crags', 'region_id', 'uuid' );
 SELECT col_is_null( 'crags', 'region_id' );
 SELECT fk_ok( 'crags', 'region_id', 'regions', 'id' );
 

--- a/schema/t/climb/formations.pg
+++ b/schema/t/climb/formations.pg
@@ -6,7 +6,7 @@ SET search_path TO climb,public;
 SELECT has_table( 'formations' );
 
 SELECT has_column( 'formations', 'id' );
-SELECT col_type_is( 'formations', 'id', 'integer' );
+SELECT col_type_is( 'formations', 'id', 'uuid' );
 SELECT col_is_pk( 'formations', 'id' );
 
 SELECT has_column( 'formations', 'name' );
@@ -22,17 +22,17 @@ SELECT col_type_is( 'formations', 'geom', 'geometry(Geometry,4326)' );
 SELECT col_is_null( 'formations', 'geom' );
 
 SELECT has_column( 'formations', 'region_id' );
-SELECT col_type_is( 'formations', 'region_id', 'integer' );
+SELECT col_type_is( 'formations', 'region_id', 'uuid' );
 SELECT col_is_null( 'formations', 'region_id' );
 SELECT fk_ok( 'formations', 'region_id', 'regions', 'id' );
 
 SELECT has_column( 'formations', 'crag_id' );
-SELECT col_type_is( 'formations', 'crag_id', 'integer' );
+SELECT col_type_is( 'formations', 'crag_id', 'uuid' );
 SELECT col_is_null( 'formations', 'crag_id' );
 SELECT fk_ok( 'formations', 'crag_id', 'crags', 'id' );
 
 SELECT has_column( 'formations', 'sector_id' );
-SELECT col_type_is( 'formations', 'sector_id', 'integer' );
+SELECT col_type_is( 'formations', 'sector_id', 'uuid' );
 SELECT col_is_null( 'formations', 'sector_id' );
 SELECT fk_ok( 'formations', 'sector_id', 'sectors', 'id' );
 

--- a/schema/t/climb/regions.pg
+++ b/schema/t/climb/regions.pg
@@ -6,7 +6,7 @@ SET search_path TO climb,public;
 SELECT has_table( 'regions' );
 
 SELECT has_column( 'regions', 'id' );
-SELECT col_type_is( 'regions', 'id', 'integer' );
+SELECT col_type_is( 'regions', 'id', 'uuid' );
 SELECT col_is_pk( 'regions', 'id' );
 
 SELECT has_column( 'regions', 'name' );

--- a/schema/t/climb/sectors.pg
+++ b/schema/t/climb/sectors.pg
@@ -6,7 +6,7 @@ SET search_path TO climb,public;
 SELECT has_table( 'sectors' );
 
 SELECT has_column( 'sectors', 'id' );
-SELECT col_type_is( 'sectors', 'id', 'integer' );
+SELECT col_type_is( 'sectors', 'id', 'uuid' );
 SELECT col_is_pk( 'sectors', 'id' );
 
 SELECT has_column( 'sectors', 'name' );
@@ -18,7 +18,7 @@ SELECT col_type_is( 'sectors', 'description', 'text' );
 SELECT col_is_null( 'sectors', 'description' );
 
 SELECT has_column( 'sectors', 'crag_id' );
-SELECT col_type_is( 'sectors', 'crag_id', 'integer' );
+SELECT col_type_is( 'sectors', 'crag_id', 'uuid' );
 SELECT col_not_null( 'sectors', 'crag_id' );
 SELECT fk_ok( 'sectors', 'crag_id', 'crags', 'id' );
 

--- a/seeds/deploy/ascent-members.sql
+++ b/seeds/deploy/ascent-members.sql
@@ -7,15 +7,15 @@ BEGIN;
 
 CREATE TABLE ascent_member_seed_refs (
     ref TEXT PRIMARY KEY,
-    ascent_id INTEGER NOT NULL,
-    climber_id INTEGER NOT NULL,
+    ascent_id UUID NOT NULL,
+    climber_id UUID NOT NULL,
     FOREIGN KEY (ascent_id, climber_id)
         REFERENCES climb.ascent_members(ascent_id, climber_id)
         ON DELETE CASCADE
 );
 
 CREATE FUNCTION ascent_member_seed_ref(p_ref TEXT)
-RETURNS TABLE(ref TEXT, ascent_id INT, climber_id INT) LANGUAGE sql STABLE AS $$
+RETURNS TABLE(ref TEXT, ascent_id UUID, climber_id UUID) LANGUAGE sql STABLE AS $$
     SELECT ref, ascent_id, climber_id
     FROM ascent_member_seed_refs
     WHERE ref = p_ref;

--- a/seeds/deploy/ascents.sql
+++ b/seeds/deploy/ascents.sql
@@ -6,11 +6,11 @@ BEGIN;
 
 CREATE TABLE ascent_seed_refs (
     ref TEXT PRIMARY KEY,
-    ascent_id INT NOT NULL REFERENCES climb.ascents(id) ON DELETE CASCADE
+    ascent_id UUID NOT NULL REFERENCES climb.ascents(id) ON DELETE CASCADE
 );
 
 CREATE FUNCTION ascent_seed_ref(p_ref TEXT)
-RETURNS TABLE(ref TEXT, ascent_id INT) LANGUAGE sql STABLE AS $$
+RETURNS TABLE(ref TEXT, ascent_id UUID) LANGUAGE sql STABLE AS $$
     SELECT ref, ascent_id
     FROM ascent_seed_refs
     WHERE ref = p_ref;

--- a/seeds/deploy/climbers.sql
+++ b/seeds/deploy/climbers.sql
@@ -5,11 +5,11 @@ BEGIN;
 
 CREATE TABLE climber_seed_refs (
     ref TEXT PRIMARY KEY,
-    climber_id INT NOT NULL REFERENCES climb.climbers(id) ON DELETE CASCADE
+    climber_id UUID NOT NULL REFERENCES climb.climbers(id) ON DELETE CASCADE
 );
 
 CREATE FUNCTION climber_seed_ref(p_ref TEXT)
-RETURNS TABLE(ref TEXT, climber_id INT) LANGUAGE sql STABLE AS $$
+RETURNS TABLE(ref TEXT, climber_id UUID) LANGUAGE sql STABLE AS $$
     SELECT ref, climber_id
     FROM climber_seed_refs
     WHERE ref = p_ref;

--- a/seeds/deploy/climbs.sql
+++ b/seeds/deploy/climbs.sql
@@ -6,11 +6,11 @@ BEGIN;
 
 CREATE TABLE climb_seed_refs (
     ref TEXT PRIMARY KEY,
-    climb_id INT NOT NULL REFERENCES climb.climbs(id) ON DELETE CASCADE
+    climb_id UUID NOT NULL REFERENCES climb.climbs(id) ON DELETE CASCADE
 );
 
 CREATE FUNCTION climb_seed_ref(p_ref TEXT)
-RETURNS TABLE(ref TEXT, climb_id INT) LANGUAGE sql STABLE AS $$
+RETURNS TABLE(ref TEXT, climb_id UUID) LANGUAGE sql STABLE AS $$
     SELECT ref, climb_id
     FROM climb_seed_refs
     WHERE ref = p_ref;

--- a/seeds/deploy/crags.sql
+++ b/seeds/deploy/crags.sql
@@ -6,11 +6,11 @@ BEGIN;
 
 CREATE TABLE crag_seed_refs (
     ref TEXT PRIMARY KEY,
-    crag_id INT NOT NULL REFERENCES climb.crags(id) ON DELETE CASCADE
+    crag_id UUID NOT NULL REFERENCES climb.crags(id) ON DELETE CASCADE
 );
 
 CREATE FUNCTION crag_seed_ref(p_ref TEXT)
-RETURNS TABLE(ref TEXT, crag_id INT) LANGUAGE sql STABLE AS $$
+RETURNS TABLE(ref TEXT, crag_id UUID) LANGUAGE sql STABLE AS $$
     SELECT ref, crag_id
     FROM crag_seed_refs
     WHERE ref = p_ref;

--- a/seeds/deploy/formations.sql
+++ b/seeds/deploy/formations.sql
@@ -6,11 +6,11 @@ BEGIN;
 
 CREATE TABLE formation_seed_refs (
     ref TEXT PRIMARY KEY,
-    formation_id INT NOT NULL REFERENCES climb.formations(id) ON DELETE CASCADE
+    formation_id UUID NOT NULL REFERENCES climb.formations(id) ON DELETE CASCADE
 );
 
 CREATE FUNCTION formation_seed_ref(p_ref TEXT)
-RETURNS TABLE(ref TEXT, formation_id INT) LANGUAGE sql STABLE AS $$
+RETURNS TABLE(ref TEXT, formation_id UUID) LANGUAGE sql STABLE AS $$
     SELECT ref, formation_id
     FROM formation_seed_refs
     WHERE ref = p_ref;

--- a/seeds/deploy/regions.sql
+++ b/seeds/deploy/regions.sql
@@ -5,12 +5,12 @@ BEGIN;
 
 CREATE TABLE region_seed_refs (
     ref TEXT PRIMARY KEY,
-    region_id INT NOT NULL REFERENCES climb.regions(id) ON DELETE CASCADE
+    region_id UUID NOT NULL REFERENCES climb.regions(id) ON DELETE CASCADE
 );
 
 -- TODO I'd like this to return the row of the regions table
 CREATE FUNCTION region_seed_ref(p_ref TEXT)
-RETURNS TABLE(ref TEXT, region_id INT) LANGUAGE sql STABLE AS $$
+RETURNS TABLE(ref TEXT, region_id UUID) LANGUAGE sql STABLE AS $$
     SELECT ref, region_id
     FROM region_seed_refs
     WHERE ref = p_ref;

--- a/seeds/deploy/sectors.sql
+++ b/seeds/deploy/sectors.sql
@@ -6,11 +6,11 @@ BEGIN;
 
 CREATE TABLE sector_seed_refs (
     ref TEXT PRIMARY KEY,
-    sector_id INT NOT NULL REFERENCES climb.sectors(id) ON DELETE CASCADE
+    sector_id UUID NOT NULL REFERENCES climb.sectors(id) ON DELETE CASCADE
 );
 
 CREATE FUNCTION sector_seed_ref(p_ref TEXT)
-RETURNS TABLE(ref TEXT, sector_id INT) LANGUAGE sql STABLE AS $$
+RETURNS TABLE(ref TEXT, sector_id UUID) LANGUAGE sql STABLE AS $$
     SELECT ref, sector_id
     FROM sector_seed_refs
     WHERE ref = p_ref;


### PR DESCRIPTION
The idea here is to allow for easier use with distributed systems and to avoid the natural tendency to associate sequential integers with meaning where there is no meaning.

The default is to generate a uuid-v7 (v7 for better indexing).