### PR TITLE
feat(scripts): auto-fill slug from name in add scripts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,9 +56,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y bats
 
-      - name: Test daterange.sh
-        run: bats scripts/daterange.bats
-
-      - name: Test geom.sh
-        run: bats scripts/geom.bats
+      - name: Test scripts
+        run: bats scripts/*.bats
 

--- a/scripts/add-climb.sql
+++ b/scripts/add-climb.sql
@@ -1,7 +1,11 @@
 \echo 'Add a new climb'
 
 \prompt 'Name: ' name
-\prompt 'Slug: ' slug
+\set default_slug `scripts/slug.sh :'name'`
+\set slug_prompt 'Slug [' :default_slug ']: '
+\prompt :slug_prompt slug
+select coalesce(nullif(:'slug', ''), :'default_slug') as slug
+\gset
 \prompt 'Grade: ' grade
 
 -- Search for parent

--- a/scripts/add-climber.sql
+++ b/scripts/add-climber.sql
@@ -1,7 +1,11 @@
 \echo 'Add a new climber'
 \prompt 'First Name: ' first_name
 \prompt 'Last Name: ' last_name
-\prompt 'Slug: ' slug
+\set default_slug `scripts/slug.sh :'first_name' :'last_name'`
+\set slug_prompt 'Slug [' :default_slug ']: '
+\prompt :slug_prompt slug
+select coalesce(nullif(:'slug', ''), :'default_slug') as slug
+\gset
 
 BEGIN;
 

--- a/scripts/add-crag.sql
+++ b/scripts/add-crag.sql
@@ -1,7 +1,11 @@
 \echo 'Add a new crag'
 
 \prompt 'Name: ' name
-\prompt 'Slug: ' slug
+\set default_slug `scripts/slug.sh :'name'`
+\set slug_prompt 'Slug [' :default_slug ']: '
+\prompt :slug_prompt slug
+select coalesce(nullif(:'slug', ''), :'default_slug') as slug
+\gset
 
 \set region_row `scripts/select.sh :'DBNAME' region -- --prompt="Select region > "`
 \set region_id `echo :'region_row' | cut -f1`

--- a/scripts/add-formation.sql
+++ b/scripts/add-formation.sql
@@ -1,7 +1,11 @@
 \echo 'Add a new formation'
 
 \prompt 'Name: ' name
-\prompt 'Slug: ' slug
+\set default_slug `scripts/slug.sh :'name'`
+\set slug_prompt 'Slug [' :default_slug ']: '
+\prompt :slug_prompt slug
+select coalesce(nullif(:'slug', ''), :'default_slug') as slug
+\gset
 
 \prompt 'Geometry: ' raw_geom
 

--- a/scripts/add-region.sql
+++ b/scripts/add-region.sql
@@ -1,6 +1,10 @@
 \echo 'Add a new region'
 \prompt 'Name: ' name
-\prompt 'Slug: ' slug
+\set default_slug `scripts/slug.sh :'name'`
+\set slug_prompt 'Slug [' :default_slug ']: '
+\prompt :slug_prompt slug
+select coalesce(nullif(:'slug', ''), :'default_slug') as slug
+\gset
 
 BEGIN;
 

--- a/scripts/add-sector.sql
+++ b/scripts/add-sector.sql
@@ -1,7 +1,11 @@
 \echo 'Add a new sector'
 
 \prompt 'Name: ' name
-\prompt 'Slug: ' slug
+\set default_slug `scripts/slug.sh :'name'`
+\set slug_prompt 'Slug [' :default_slug ']: '
+\prompt :slug_prompt slug
+select coalesce(nullif(:'slug', ''), :'default_slug') as slug
+\gset
 
 \set crag_row `scripts/select.sh :'DBNAME' crag -- --prompt="Select crag > "`
 \set crag_id `echo :'crag_row' | cut -f1`

--- a/scripts/slug.bats
+++ b/scripts/slug.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+setup() {
+  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  SLUG="$DIR/slug.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Basics
+# ---------------------------------------------------------------------------
+
+@test "simple name" {
+  run "$SLUG" 'El Capitan'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'el-capitan' ]
+}
+
+@test "lowercases" {
+  run "$SLUG" 'EL CAPITAN'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'el-capitan' ]
+}
+
+@test "digits are preserved" {
+  run "$SLUG" 'Route 66'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'route-66' ]
+}
+
+@test "already a slug is unchanged" {
+  run "$SLUG" 'el-capitan'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'el-capitan' ]
+}
+
+# ---------------------------------------------------------------------------
+# Apostrophes
+# ---------------------------------------------------------------------------
+
+@test "apostrophe is stripped, not hyphenated" {
+  run "$SLUG" "Devil's Tower"
+  [ "$status" -eq 0 ]
+  [ "$output" = 'devils-tower' ]
+}
+
+# ---------------------------------------------------------------------------
+# Separators and punctuation collapse to a single hyphen
+# ---------------------------------------------------------------------------
+
+@test "em dash and surrounding spaces collapse to one hyphen" {
+  run "$SLUG" 'El Capitan — The Nose'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'el-capitan-the-nose' ]
+}
+
+@test "runs of spaces and punctuation collapse" {
+  run "$SLUG" 'The  Nose!!!'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'the-nose' ]
+}
+
+# ---------------------------------------------------------------------------
+# Trimming leading/trailing hyphens
+# ---------------------------------------------------------------------------
+
+@test "leading and trailing whitespace is trimmed" {
+  run "$SLUG" '  The Nose  '
+  [ "$status" -eq 0 ]
+  [ "$output" = 'the-nose' ]
+}
+
+@test "leading and trailing separators are trimmed" {
+  run "$SLUG" '—Nose—'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'nose' ]
+}
+
+# ---------------------------------------------------------------------------
+# Argument handling
+# ---------------------------------------------------------------------------
+
+@test "multiple arguments are joined with a space" {
+  run "$SLUG" The Nose
+  [ "$status" -eq 0 ]
+  [ "$output" = 'the-nose' ]
+}
+
+@test "empty input yields empty output" {
+  run "$SLUG" ''
+  [ "$status" -eq 0 ]
+  [ "$output" = '' ]
+}

--- a/scripts/slug.sh
+++ b/scripts/slug.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Derive a URL-safe slug from a name.
+#
+# Source it to use the `slugify` function, or run it directly:
+#   scripts/slug.sh "El Capitan — The Nose"  ->  el-capitan-the-nose
+
+slugify() {
+  printf '%s' "$*" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E "s/'//g; s/[^a-z0-9]+/-/g; s/^-+//; s/-+$//"
+}
+
+# Run as a script (rather than sourced): slugify the arguments.
+if [ "${0##*/}" = "slug.sh" ]; then
+  slugify "$@"
+fi


### PR DESCRIPTION
Add scripts/slug.sh helper that derives a URL-safe slug from a name (lowercased, apostrophes stripped, other non-alphanumeric runs collapsed to hyphens). The add-* scripts now offer the derived slug as the default at the prompt, overridable by typing one.