### PR TITLE
feat(scripts)!: simplify inputs

### DIFF
--- a/scripts/add-ascent.sql
+++ b/scripts/add-ascent.sql
@@ -24,8 +24,13 @@ SELECT :'raw_ascent_window' != '' as ascent_window_provided
 \endif
 
 \prompt 'Description: ' description
-\prompt 'Style (comma-separated): ' style
-\prompt 'Significance (comma-separated): ' significance
+\prompt 'First ascent? (y/N): ' first_ascent
+
+\if :first_ascent
+  \set significance '{first-ascent}'
+\else
+  \set significance '{}'
+\endif
 
 \echo 'Select ascent members (TAB to multi-select, ENTER to confirm)'
 
@@ -40,21 +45,13 @@ INSERT INTO climb.ascents (
   climb_id,
   ascent_window,
   description,
-  style,
   significance
 ) VALUES (
   :'ascent_id'::uuid,
   nullif(:'climb_id','')::uuid,
   nullif(:'ascent_window','')::daterange,
   nullif(:'description',''),
-  CASE
-    WHEN nullif(:'style','') IS NULL THEN '{}'::text[]
-    ELSE string_to_array(replace(:'style',' ',''), ',')
-  END,
-  CASE
-    WHEN nullif(:'significance','') IS NULL THEN '{}'::text[]
-    ELSE string_to_array(replace(:'significance',' ',''), ',')
-  END
+  :'significance'::text[]
 ) RETURNING *;
 
 INSERT INTO climb.ascent_members (ascent_id, climber_id)


### PR DESCRIPTION
Style has not been used much by me because it must apply to the whole ascent, so things like "redpoint/worked" must apply to each member, which often may not be correct.

Currently, significance has only been used for marking first ascents. So, to simplify this concept, the significance prompt has been replaced with a first ascent boolean prompt.